### PR TITLE
Update build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,22 +17,30 @@ matrix:
         # Current $required_php_version for WordPress: 5.2.4
         # aliased to 5.2.17
         - php: '5.2'
+          dist: precise
         # aliased to a recent 5.6.x version
         - php: '5.6'
+          dist: trusty
           env: SNIFF=1
+        # aliased to a recent 7.1 version
+        - php: '7.1'
+          dist: trusty
 
 before_script:
   - export PHPCS_DIR=/tmp/phpcs
   - export WPCS_DIR=/tmp/wpcs
+  - export PHPCOMPAT_DIR=/tmp/phpcompatibility
   # Install CodeSniffer for WordPress Coding Standards checks.
   - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
   # Install WordPress Coding Standards.
   - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
+  # Install PHPCompatibility.
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
   # Hop into CodeSniffer directory.
   - if [[ "$SNIFF" == "1" ]]; then cd $PHPCS_DIR; fi
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
   # Hop back into project dir.
   - if [[ "$SNIFF" == "1" ]]; then cd $TRAVIS_BUILD_DIR; fi
   # After CodeSniffer install you should refresh your path.
@@ -44,11 +52,11 @@ before_script:
 script:
   # Search for PHP syntax errors.
   - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-  # WordPress Coding Standards.
+  # Check for code style using the WordPress Coding Standards and for PHP cross-version compatibility.
   # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+  # @link https://github.com/wimg/PHPCompatibility
   # @link https://github.com/squizlabs/PHP_CodeSniffer
-  # All of the usual config flags are held in phpcs.xml
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -v . --standard=WordPress --extensions=php; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs -p -s -v . --standard=WordPress,PHPCompatibility --runtime-set testVersion 5.2-; fi
 
 notifications:
   email: false


### PR DESCRIPTION
* Set the `dist` travis variable so the build can run on PHP 5.2.
* Also lint on PHP 7.1 (current highest PHP version)
* Add the PHPCompatibility standard to sniff against
* Make the necessary changes for things to work with PHPCS 3.x

(The script needs to be updated so the next PR with a changelog for v1.0.2 can pass)